### PR TITLE
Add campaign link

### DIFF
--- a/joinLobby.html
+++ b/joinLobby.html
@@ -20,6 +20,6 @@
 </head>
 <body>
     <h1>Redirecting to the AppStore...</h1>
-    <p>If you are not redirected automatically, <a href="https://apps.apple.com/app/id1546705439">click here</a>.</p>
+    <p>If you are not redirected automatically, <a href="https://apps.apple.com/app/apple-store/id1546705439?pt=120505680&ct=sharelobbycode&mt=8">click here</a>.</p>
 </body>
 </html>

--- a/joinLobby.html
+++ b/joinLobby.html
@@ -7,7 +7,7 @@
     <title>Redirecting to App Store</title>
     <script>
         function redirectToAppStore() {
-            const appStoreLink = "https://apps.apple.com/app/id1546705439";
+            const appStoreLink = "https://apps.apple.com/app/apple-store/id1546705439?pt=120505680&ct=sharelobbycode&mt=8";
             const fallbackTimeout = 1000;
 
             setTimeout(() => {


### PR DESCRIPTION
took the link from app analytics in appstoreconnect. we can use any alphanumeric characters up to 30 char, there are no special steps to this, and it will only show up on appstoreconnect if downloaded more than 5 times using this campaign code