### PR TITLE
Show and optimize app store badges on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -588,5 +588,19 @@ footer a:hover {
 .app-badges img {
   height: 54px;
   width: auto;
+  max-width: 100%;
   vertical-align: middle;
+}
+
+@media (max-width: 480px) {
+  .app-badges a {
+    display: block;
+  }
+  .app-badges a + a {
+    margin-left: 0;
+    margin-top: 12px;
+  }
+  .app-badges img {
+    height: 48px;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
                         <p>Compared to the other variations of Mahjong around the world, there are four additional animal tiles (mouse, cockerel, cat, and the centipede) and an alternative scoring system in Singapore Mahjong.</p>
                         <p>Read more about MahjongLeh's rules <a href="https://playleh.com/mahjongleh-rules.html">here</a>.</p>
                         <p class="app-badges wow fadeInUp" data-wow-delay="0.8s">
-                            <a href="https://apps.apple.com/sg/app/mahjongleh/id1546705439"><img src="images/badge.png" alt="Download on the App Store"></a>
-                            <a href="https://play.google.com/store/apps/details?id=com.playleh.mahjongleh"><img src="images/google-play-badge.png" alt="Get it on Google Play"></a>
+                            <a href="https://apps.apple.com/sg/app/mahjongleh/id1546705439"><img src="images/badge.png" width="160" height="54" alt="Download on the App Store"></a>
+                            <a href="https://play.google.com/store/apps/details?id=com.playleh.mahjongleh"><img src="images/google-play-badge.png" width="173" height="54" alt="Get it on Google Play"></a>
                         </p>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                         <p>MahjongLeh follows the Singapore's twist on the popular table game, Mahjong.</p>
                         <p>Compared to the other variations of Mahjong around the world, there are four additional animal tiles (mouse, cockerel, cat, and the centipede) and an alternative scoring system in Singapore Mahjong.</p>
                         <p>Read more about MahjongLeh's rules <a href="https://playleh.com/mahjongleh-rules.html">here</a>.</p>
-                        <p class="app-badges wow fadeInUp hidden-xs" data-wow-delay="0.8s">
+                        <p class="app-badges wow fadeInUp" data-wow-delay="0.8s">
                             <a href="https://apps.apple.com/sg/app/mahjongleh/id1546705439"><img src="images/badge.png" alt="Download on the App Store"></a>
                             <a href="https://play.google.com/store/apps/details?id=com.playleh.mahjongleh"><img src="images/google-play-badge.png" alt="Get it on Google Play"></a>
                         </p>


### PR DESCRIPTION
## Problem

The **Download on the App Store** and **Get it on Google Play** badges were not visible on mobile viewports. The badges paragraph carried Bootstrap's `hidden-xs` class, which hides the element on extra-small screens — so mobile visitors had no way to reach the app store links from the homepage.

## Fix

- Removed `hidden-xs` from the badges so they render on all screen sizes.
- Added responsive CSS: on screens ≤480px the badges stack vertically, scale down slightly (48px), and never overflow their container (`max-width: 100%`).

## Verification

Previewed the homepage at mobile (375px) and desktop widths:

- **Mobile:** badges now visible, stacked vertically, fully sized.
- **Desktop:** unchanged — badges remain side by side.