### PR TITLE
Disclose upcoming Firebase authentication

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -61,57 +61,60 @@ http://www.templatemo.com/tm-490-comila
                             <p>
                                 If you choose to use the application, then you agree to
                                 the collection and use of information in relation to this
-                                policy. The Personal Information that I collect is
-                                used for providing and improving the Service. I will not use or share your information with
+                                policy. The Personal Information that we collect is
+                                used for providing and improving the Service. We will not use or share your information with
                                 anyone except as described in this Privacy Policy.
                             </p>
+                            <h3>Information Collection and Use</h3>
+                            <h4>Personal Information</h4>
                             <p>
-                                <h3>Information Collection and Use</h3>
+                                The application uses pseudonymous account and device identifiers as described below. These identifiers do not contain your name, email address, or phone number, but they may still be treated as personal data under applicable law because they can distinguish an account, application installation, or device.
+                            </p>
+                            <h4>Authentication and Account Identifiers</h4>
+                            <p>
+                                The application uses Google Firebase Authentication. If you do not explicitly sign in, the application automatically creates or restores a Firebase anonymous guest account in the background. This allows account continuity and provides the foundation for future Supporter features. Explicit Apple or Google sign-in is optional; if you choose it when available, the existing guest account may be linked to that provider so that you can recover the same account on another device. Firebase and the selected provider process provider-issued credentials and may provide an account identifier and profile information permitted by you, such as a name or email address. The application does not send provider passwords to PlayLeh.
+                            </p>
+                            <h4>Service Providers</h4>
+                            <p>
+                                Google Firebase provides Authentication, Analytics, and Crashlytics services. Google AdMob provides advertising services. These providers process information on our behalf or under their own applicable terms and privacy policies.
+                            </p>
+                            <h4>Analytics</h4>
+                            <p>
+                                When analytics collection is permitted by the privacy choices applicable to you, Google Analytics for Firebase may collect information about your application installation and device, application interactions, usage frequency, approximate location derived from network information, and similar technologies. The application sets a pseudonymous Analytics User-ID derived by applying a domain-separated SHA-256 hash to the Firebase account identifier. The raw Firebase account identifier, your email address, and Apple or Google credentials are not sent as Analytics event parameters.
                             </p>
                             <p>
-                                <h4>Personal Information</h4>
-                            </p>
-                            <p>This App does not collect or store any personal information</p>
-                            <p>
-                                <h4>Service Providers</h4>
+                                This pseudonymous User-ID helps us understand cross-device use, measure account and Supporter feature reliability, support account recovery, and investigate potential account-sharing patterns. Multiple devices can be legitimate, so Analytics signals are not used by themselves to make automatic entitlement or account-ban decisions. If analytics collection is not permitted, the account identifier is not exported through Analytics.
                             </p>
                             <p>
-                                <h4>Analytics</h4>
-                            </p>
-                            <p>
-                                Information about your device, cookies and similar technologies may be collected by a Third-Party service (Google Analytics for Firebase). These may include location, usage frequency and unique device ID. The usage of this information by the Third-Party provider is not covered within this policy. Refer to the link below for more information:
+                                A cryptographic hash is pseudonymous rather than anonymous data. Google Analytics for Firebase also uses its own application-instance identifier. Refer to the link below for more information:
                             </p>
                             <p><a href="https://firebase.google.com/policies/analytics">https://firebase.google.com/policies/analytics</a></p>
-                            <p>
-                                <h4>Advertising</h4>
-                            </p>
+                            <h4>Advertising</h4>
                             <p>
                                 Ads are displayed in the game, via a Third-Party service (Admob, Google). Information about your mobile device or usage may be collected. These may include location and usage frequency, unique device ID, advertising ID as well as ad interaction information. The usage of this information by the Third-Party provider is not covered within this policy. Refer to the link below for more information:
                             </p>
                             <p><a href="https://policies.google.com/technologies/partner-sites">https://policies.google.com/technologies/partner-sites</a></p>
-                            <p>
-                                <h4>Crash and Diagnostic Data</h4>
-                            </p>
+                            <h4>Crash and Diagnostic Data</h4>
                             <p>
                                 To keep the application stable and fix problems, crash reports and diagnostic information (such as device model, operating system version, and application version) may be collected by a Third-Party service (Google Firebase Crashlytics). The usage of this information by the Third-Party provider is not covered within this policy. Refer to the link below for more information:
                             </p>
                             <p><a href="https://firebase.google.com/support/privacy">https://firebase.google.com/support/privacy</a></p>
+                            <h4>Online Multiplayer</h4>
                             <p>
-                                <h4>Online Multiplayer</h4>
+                                When you play online (Quick Match or private rooms), the display name you choose, a device-derived gameplay identifier, and your in-game actions are sent to our game server. Your display name and in-game actions are shown to the other players in your game. The gameplay identifier is separate from your Firebase account identifier and is processed to run the live game. Explicit Apple or Google sign-in is not required for Classic play because an anonymous guest account is used when you do not sign in.
                             </p>
-                            <p>
-                                When you play online (Quick Match or private rooms), the display name you choose and your in-game actions are sent to our game server and shown to the other players in your game. The display name is not used to identify you personally and no account is required. This information is processed only to run the live game.
-                            </p>
-                            <p>
-                                <h4>Data Security</h4>
-                            </p>
+                            <h4>Data Security</h4>
                             <p>
                                 All communication between the application and our servers is encrypted in transit (TLS / HTTPS / WSS).
                             </p>
-                        </p>
-                        <p>
-                            <h4>Children’s Privacy</h4>
-                        </p>
+                            <h4>Data Retention and Deletion</h4>
+                            <p>
+                                Firebase account identifiers are retained to provide account continuity until the account is deleted or an applicable retention policy removes it. Analytics, crash, diagnostic, and advertising information is retained according to our configured settings and the relevant service provider's policies. Anonymous-account cleanup may be applied after an appropriate retention period, but you should not rely on automatic cleanup as a deletion request.
+                            </p>
+                            <p>
+                                You may request deletion of your Firebase account and related data by contacting contact@playleh.com. We may ask for an account or support identifier available through the application so that we can locate the correct record. When an in-application account deletion option is available, you may also initiate deletion there. Uninstalling the application, signing out, or declining Analytics consent does not by itself delete a Firebase account or information already retained by a service provider.
+                            </p>
+                        <h4>Children’s Privacy</h4>
                         <p>
                             The application does not address anyone under the age of 17.
                             We do not knowingly collect personally
@@ -123,17 +126,15 @@ http://www.templatemo.com/tm-490-comila
                             personal information, please contact us at contact@playleh.com so that
                             we will be able to do necessary actions.
                         </p>
-                        <p>
-                            <h4>Changes to This Privacy Policy</h4>
-                        </p>
+                        <h4>Changes to This Privacy Policy</h4>
                         <p>
                             We may update our Privacy Policy from
                             time to time. Thus, you are advised to review this page
-                            periodically for any changes. we will
+                            periodically for any changes. We will
                             notify you of any changes by posting the new Privacy Policy on
                             this page.
                         </p>
-                        <p>This policy is effective as of 2021-11-06. Last updated 2026-06-12.</p>
+                        <p>This policy is effective as of 2021-11-06. Last updated 2026-07-21.</p>
                     </div>
                 </div>
             </div>
@@ -167,13 +168,13 @@ http://www.templatemo.com/tm-490-comila
                 </div>
                 <div class="wow fadeInUp" data-wow-delay="0.3s">
                     <p class="copyright-text">Copyright &copy; 2026 PlayLeh LLP <br>
-                    </div>
                     Designed by <a rel="nofollow" href="http://www.google.com/+templatemo" target="_parent">Templatemo</a></p>
                 </div>
                 <div class="col-md-1 col-sm-1"></div>
                 <div class="col-md-4 col-sm-5"></div>
             </div>
         </div>
+    </div>
     </footer>
     <!-- Back top -->
     <a href="#back-top" class="go-top"><i class="fa fa-angle-up"></i></a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -109,7 +109,7 @@ http://www.templatemo.com/tm-490-comila
                             </p>
                             <h4>Data Retention and Deletion</h4>
                             <p>
-                                Firebase account identifiers are retained to provide account continuity until the account is deleted or an applicable retention policy removes it. Analytics, crash, diagnostic, and advertising information is retained according to our configured settings and the relevant service provider's policies. Anonymous-account cleanup may be applied after an appropriate retention period, but you should not rely on automatic cleanup as a deletion request.
+                                Firebase account identifiers are retained to provide account continuity until the account is deleted. Analytics, crash, diagnostic, and advertising information is retained according to our configured settings and the relevant service provider's policies.
                             </p>
                             <p>
                                 You may request deletion of your Firebase account and related data by contacting contact@playleh.com. We may ask for an account or support identifier available through the application so that we can locate the correct record. When an in-application account deletion option is available, you may also initiate deletion there. Uninstalling the application, signing out, or declining Analytics consent does not by itself delete a Firebase account or information already retained by a service provider.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,7 +21,7 @@
 </url>
 <url>
   <loc>https://playleh.com/privacy-policy.html</loc>
-  <lastmod>2026-01-19T09:25:55+00:00</lastmod>
+  <lastmod>2026-07-21T00:00:00+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 </urlset>


### PR DESCRIPTION
## Summary

Prepare the public MahjongLeh privacy policy for the Firebase account foundation in
MahjongLeh 1303.

The existing policy said that the app collected no personal information and required no account.
Those statements become inaccurate when the app automatically creates or restores a Firebase
anonymous guest account.

## Disclosure changes

| Data flow | Public disclosure |
| --- | --- |
| Guest play | Firebase Authentication creates or restores an anonymous account when the player does not explicitly sign in |
| Future recovery | Optional Apple/Google credentials may link the existing guest account; provider passwords are not sent to PlayLeh |
| Analytics | When the applicable privacy choices permit collection, Analytics receives a domain-separated SHA-256 hash of Firebase UID, not the raw UID |
| Account-sharing patterns | Cross-device signals may be reviewed, but are not sufficient by themselves for automatic entitlement or ban decisions |
| Classic networking | The device-derived gameplay identifier remains distinct from the Firebase account identifier |
| Retention/deletion | Explains account retention, deletion requests, and that uninstall/sign-out/consent denial do not themselves delete an Auth account |

The policy also identifies Firebase Authentication as a service provider, updates its date, and
fixes invalid heading/footer nesting in the touched HTML. `sitemap.xml` now carries the policy's
current modification date.

## Release gate

This site disclosure is necessary but is **not sufficient by itself** for the iOS launch. Apple
requires apps that support account creation to let users initiate deletion inside the app.

The current client Supporter feature implements in-app deletion for both anonymous guests and linked
accounts. A user-visible Support ID is not a prerequisite for guest deletion: the app acts through
the guest's current verified Firebase session. Support remains a recovery fallback and must use
server-side lookup/verification procedures; users must never be asked to email Firebase UIDs,
tokens, provider credentials, passwords, or receipts.

The external uninstalled-app recovery/deletion path is stacked separately in
[playleh.com PR #25](https://github.com/quanyang/playleh.com/pull/25). Its real-provider browser
matrix and an explicit later go-live decision remain required before publishing that page.

## Validation

- `git diff --check` — passed.
- `tidy -errors -quiet privacy-policy.html` — structurally valid HTML5; only the existing empty icon warning remains.
- Reviewed against the account contract and privacy boundary in MahjongLeh PR #1303.

Official references:

- [Firebase privacy and retention information](https://firebase.google.com/support/privacy/)
- [Apple in-app account-deletion guidance](https://developer.apple.com/support/offering-account-deletion-in-your-app)
